### PR TITLE
Add DELETE endpoint for visits and update CORS policy

### DIFF
--- a/vidro.api/Feature/Visit/VisitController.cs
+++ b/vidro.api/Feature/Visit/VisitController.cs
@@ -105,5 +105,28 @@ namespace vidro.api.Feature.Visit
 
             return Created($"/visits/{response.Id}", response);
         }
+
+        [HttpDelete]
+        [Route("/visits/{id}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult> DeleteVisitAsync(int id, CancellationToken cancellationToken)
+        {
+            var visit = await _context.Visits
+                .Where(v => v.Id == id && !v.IsDeleted)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (visit is null)
+            {
+                return NotFound();
+            }
+
+            visit.IsDeleted = true;
+
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            return NoContent();
+        }
     }
 }

--- a/vidro.api/Program.cs
+++ b/vidro.api/Program.cs
@@ -32,8 +32,6 @@ internal class Program
             options.AddPolicy("Production", policy =>
             {
                 policy.WithOrigins(
-                        "https://yourdomain.com", 
-                        "https://www.yourdomain.com",
                         "http://localhost:8081",
                         "http://localhost:3000",
                         "http://127.0.0.1:8081",


### PR DESCRIPTION
Add DELETE endpoint for visits and update CORS policy

Implemented a new HTTP DELETE endpoint in `VisitController` to allow deletion of visits by ID, with appropriate checks and responses. Updated CORS policy in `Program.cs` by removing specific origins to enhance security.